### PR TITLE
[BE] fix: gh actions workflow 수정

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -37,4 +37,11 @@ jobs:
           go get .
 
       - name: Test
+        id: build-image
+        env:
+          MYSQL_USER: ${{ secrets.MYSQL_USER }}
+          MYSQL_PASSWORD: ${{ secrets.MYSQL_PASSWORD }}
+          MYSQL_HOST: ${{ secrets.MYSQL_HOST }}
+          MYSQL_PORT: ${{ secrets.MYSQL_PORT }}
+          MYSQL_DATABASE: ${{ secrets.MYSQL_DATABASE }}
         run: go test -v -cover ./...


### PR DESCRIPTION
- gh actions 실행 시에 사용할 환경변수 추가

## 이슈
- resolve #9 
- 백엔드 개발 시 환경 변수를 infisical로 관리하고 있었는데, gh actions 실행 시 이 환경변수를 받아올 방법을 못 찾고 있었습니다.

## 작업 사항
- infisical 공식 문서의 [GitHub Actions 통합](https://infisical.com/docs/integrations/cicd/githubactions) 문서를 참고하여 작업 시작했으나, 해당 문서는 내용이 약간 빠져 있었습니다. 위 문서 참고하여 infisical 단에서 통합 등록은 했고, 그 다음으로
1. 본 레포지토리 > Settings > Secrets and variables > Actions 메뉴에 infisical 환경 변수가 등록이 되어있는지 확인합니다.
2. https://github.com/NutBooks/NutBooks/commit/584198a5920ef1f9e5db896f4d4335afc33ae24a 커밋과 같이 workflow에서 secrets에 있는 환경변수를 가져갈 수 있도록 선언을 해주어야 합니다. (integration을 하더라도 실행 시 환경변수 주입이 자동으로 이루어지지는 않았습니다.) 
  https://github.com/NutBooks/NutBooks/blob/584198a5920ef1f9e5db896f4d4335afc33ae24a/.github/workflows/go.yml#L41-L47 
3. 이제 잘 동작합니다. 
  ![image](https://github.com/NutBooks/NutBooks/assets/41780495/b2aebec2-8c25-4ee7-9c27-8386c08444f6)


## 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
