### PR TITLE
Feat/be/10 api limit

### DIFF
--- a/backend/app/root.go
+++ b/backend/app/root.go
@@ -38,8 +38,8 @@ func RunServer() {
 
 	// limit 3 requests per 10 seconds max
 	app.Use(limiter.New(limiter.Config{
-		Expiration: 10 * time.Second,
-		Max:        10,
+		Expiration: 1 * time.Hour,
+		Max:        1000,
 	}))
 
 	// https://github.com/swaggo/swag#declarative-comments-format


### PR DESCRIPTION
## 이슈

resolve #10 

## 작업 사항

- 기존에는 초당 10회로 제한했는데, 테스트 시 문제가 발생하는 경우가 있었습니다.
- API Limiter의 설정을 10초 내 10개 요청 -> 1시간 내 1000개 요청 허용으로 변경하였습니다.
  - 횟수 비율은 줄었으나 시간을 길게 주어 테스트 환경에서는 큰 문제 없을 것으로 생각됩니다.
  - 또한 배포 환경에서도 현재 Azure vm 인스턴스 크기나, 사용자 규모 면에서 당분간은 제약이 될 정도는 아니라고 판단됩니다.

## 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
