### PR TITLE
[BE] feat: 이메일 중복 체크 기능 추가, 엔드포인트 추가 (#45,#46) 

### DIFF
--- a/backend/app/controllers/controllers_test.go
+++ b/backend/app/controllers/controllers_test.go
@@ -22,9 +22,10 @@ func controllersTestApp(t *testing.T) {
 
 	// User
 	user := route.Group("/user")
-	user.Post("/", AddUserHandler)
-	user.Get("/:id/", GetUserByIdHandler)
-	user.Get("/", GetAllUsersHandler)
+	user.Post("", AddUserHandler)
+	user.Get("/:id<int>", GetUserByIdHandler)
+	user.Get("", GetAllUsersHandler)
+	user.Get("/check-email", CheckEmailDuplicateHandler)
 
 	// Auth router
 	auth := route.Group("/auth")

--- a/backend/app/controllers/user.go
+++ b/backend/app/controllers/user.go
@@ -190,3 +190,29 @@ func GetAllUsersHandler(c *fiber.Ctx) error {
 		Data:    found,
 	})
 }
+
+// CheckEmailDuplicateHandler
+//
+//	@Summary		이메일 중복 체크.
+//	@Description	입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 "True" 반환, 없다면 "False" 반환.
+//	@Tags			user
+//	@Produce		json
+//	@Param			email	query		string	true	"중복 체크 할 이메일 주소 입력. 최대 길이 50자 제한."
+//	@Success		200		{object}	models.CheckEmailDuplicateResponse{}
+//	@Failure		400		{object}	models.CheckEmailDuplicateResponse{}
+//	@Router			/api/v1/user/check-email/ [get]
+func CheckEmailDuplicateHandler(c *fiber.Ctx) error {
+	// 파라미터 파싱
+	// 파라미터 유효성 검사
+	// db 조회
+
+	isEmailDuplicated := "False"
+	// 결과가 0이 아니면 (같은 이메일을 쓰는 유저 수가 0이 아니면)
+	// 상태 코드는 200 OK 이고 isEmailDuplicated = "True"로 변경
+
+	return c.Status(fiber.StatusOK).JSON(models.CheckEmailDuplicateResponse{
+		Error:   false,
+		Message: isEmailDuplicated,
+		Data:    nil,
+	})
+}

--- a/backend/app/controllers/user_test.go
+++ b/backend/app/controllers/user_test.go
@@ -47,7 +47,7 @@ func testAddUserHandler(t *testing.T) {
 		{
 			name:   "Add  user -> success",
 			method: "POST",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.AddUserRequest{
 				Name:     "tester1",
 				Email:    "tester1@example.com",
@@ -60,7 +60,7 @@ func testAddUserHandler(t *testing.T) {
 		{
 			name:   "Add user without name and email -> fail",
 			method: "POST",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.AddUserRequest{
 				Name:     "",
 				Email:    "",
@@ -73,7 +73,7 @@ func testAddUserHandler(t *testing.T) {
 		{
 			name:   "Add user without name -> fail",
 			method: "POST",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.AddUserRequest{
 				Name:     "",
 				Email:    "tester3@example.com",
@@ -86,7 +86,7 @@ func testAddUserHandler(t *testing.T) {
 		{
 			name:   "Add user without email -> fail",
 			method: "POST",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.AddUserRequest{
 				Name:     "tester4",
 				Email:    "",
@@ -99,7 +99,7 @@ func testAddUserHandler(t *testing.T) {
 		{
 			name:   "Add user with wrong email format -> fail",
 			method: "POST",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.AddUserRequest{
 				Name:     "tester5",
 				Email:    "tester5email",
@@ -112,7 +112,7 @@ func testAddUserHandler(t *testing.T) {
 		{
 			name:   "Add user with wrong password format -> fail",
 			method: "POST",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.AddUserRequest{
 				Name:     "tester5",
 				Email:    "tester5email",
@@ -162,7 +162,7 @@ func testGetUserByIdHandler(t *testing.T) {
 		{
 			name:   "Get user of testUser1 using testUser1.ID -> success",
 			method: "GET",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.GetUserByIdRequest{
 				ID: testUser1.ID,
 			},
@@ -173,7 +173,7 @@ func testGetUserByIdHandler(t *testing.T) {
 		{
 			name:   "Get not existing user -> fail",
 			method: "GET",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.GetUserByIdRequest{
 				ID: 464749,
 			},
@@ -190,7 +190,7 @@ func testGetUserByIdHandler(t *testing.T) {
 			require.NoError(t, err)
 			t.Log("buf: ", buf)
 
-			req := httptest.NewRequest(tt.method, fmt.Sprintf("%s%d", tt.route, tt.body.ID), buf)
+			req := httptest.NewRequest(tt.method, fmt.Sprintf("%s/%d", tt.route, tt.body.ID), buf)
 			req.Header.Set("Content-Type", "application/json")
 			t.Log("req: ", req)
 
@@ -221,7 +221,7 @@ func testGetAllUsersHandler(t *testing.T) {
 		{
 			name:            "Get all users -> success",
 			method:          "GET",
-			route:           "/api/v1/user/",
+			route:           "/api/v1/user",
 			body:            models.GetAllUsersRequest{},
 			expectedError:   false,
 			expectedCode:    http.StatusOK,
@@ -230,7 +230,7 @@ func testGetAllUsersHandler(t *testing.T) {
 		{
 			name:   "Get all users using negative offset value -> fail",
 			method: "GET",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.GetAllUsersRequest{
 				Offset: -1,
 			},
@@ -241,7 +241,7 @@ func testGetAllUsersHandler(t *testing.T) {
 		{
 			name:   "Get all users using negative limit value -> fail",
 			method: "GET",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.GetAllUsersRequest{
 				Limit: -1,
 			},
@@ -252,7 +252,7 @@ func testGetAllUsersHandler(t *testing.T) {
 		{
 			name:   "Get all users using offset and limit value -> success",
 			method: "GET",
-			route:  "/api/v1/user/",
+			route:  "/api/v1/user",
 			body: models.GetAllUsersRequest{
 				Offset: int(testUser1.ID),
 				Limit:  1,
@@ -343,12 +343,12 @@ func testCheckEmailDuplicateHandler(t *testing.T) {
 
 	for _, tt := range testCases {
 		t.Run(tt.name, func(t *testing.T) {
-			req := httptest.NewRequest(tt.method, tt.route, nil)
-			q := req.URL.Query()
-			for k, v := range tt.params {
-				q.Add(k, v)
-			}
-			req.URL.RawQuery = q.Encode()
+			req := httptest.NewRequest(
+				tt.method,
+				fmt.Sprintf("%s?email=%s", tt.route, tt.params["email"]),
+				nil,
+			)
+			t.Log("req:", req)
 
 			resp, err := app.Test(req, -1)
 			t.Log("resp: ", resp)

--- a/backend/app/routes/public_route.go
+++ b/backend/app/routes/public_route.go
@@ -24,9 +24,10 @@ func PublicRoutes(app *fiber.App) {
 
 	// User router
 	user := v1.Group("/user")
-	user.Post("/", controllers.AddUserHandler)
-	user.Get("/:id/", controllers.GetUserByIdHandler)
-	user.Get("/", controllers.GetAllUsersHandler)
+	user.Post("", controllers.AddUserHandler)
+	user.Get("/:id<int>", controllers.GetUserByIdHandler)
+	user.Get("", controllers.GetAllUsersHandler)
+	user.Get("/check-email", controllers.CheckEmailDuplicateHandler)
 
 	// Auth router
 	auth := v1.Group("/auth")

--- a/backend/db/models/user.go
+++ b/backend/db/models/user.go
@@ -69,6 +69,16 @@ type (
 		Data    interface{} `json:"data"`
 		Message string      `json:"message"`
 	}
+
+	CheckEmailDuplicateRequest struct {
+		Email string `validate:"required,min=5,max=50,email" json:"email" form:"email" example:""`
+	}
+
+	CheckEmailDuplicateResponse struct {
+		Error   bool        `json:"error"`
+		Data    interface{} `json:"data"`
+		Message string      `json:"message"`
+	}
 )
 
 const (

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -228,7 +228,7 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/user/": {
+        "/api/v1/user": {
             "get": {
                 "produces": [
                     "application/json"
@@ -340,9 +340,9 @@ const docTemplate = `{
                 }
             }
         },
-        "/api/v1/user/check-email/": {
+        "/api/v1/user/check-email": {
             "get": {
-                "description": "입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 \"True\" 반환, 없다면 \"False\" 반환.",
+                "description": "입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 True 반환, 없다면 False 반환.",
                 "produces": [
                     "application/json"
                 ],
@@ -371,11 +371,17 @@ const docTemplate = `{
                         "schema": {
                             "$ref": "#/definitions/models.CheckEmailDuplicateResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.CheckEmailDuplicateResponse"
+                        }
                     }
                 }
             }
         },
-        "/api/v1/user/{id}/": {
+        "/api/v1/user/{id}": {
             "get": {
                 "produces": [
                     "application/json"

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -340,6 +340,41 @@ const docTemplate = `{
                 }
             }
         },
+        "/api/v1/user/check-email/": {
+            "get": {
+                "description": "입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 \"True\" 반환, 없다면 \"False\" 반환.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "user"
+                ],
+                "summary": "이메일 중복 체크.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "중복 체크 할 이메일 주소 입력. 최대 길이 50자 제한.",
+                        "name": "email",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CheckEmailDuplicateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.CheckEmailDuplicateResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/user/{id}/": {
             "get": {
                 "produces": [
@@ -501,6 +536,18 @@ const docTemplate = `{
                 },
                 "userID": {
                     "type": "integer"
+                }
+            }
+        },
+        "models.CheckEmailDuplicateResponse": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "error": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -328,6 +328,41 @@
                 }
             }
         },
+        "/api/v1/user/check-email/": {
+            "get": {
+                "description": "입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 \"True\" 반환, 없다면 \"False\" 반환.",
+                "produces": [
+                    "application/json"
+                ],
+                "tags": [
+                    "user"
+                ],
+                "summary": "이메일 중복 체크.",
+                "parameters": [
+                    {
+                        "type": "string",
+                        "description": "중복 체크 할 이메일 주소 입력. 최대 길이 50자 제한.",
+                        "name": "email",
+                        "in": "query",
+                        "required": true
+                    }
+                ],
+                "responses": {
+                    "200": {
+                        "description": "OK",
+                        "schema": {
+                            "$ref": "#/definitions/models.CheckEmailDuplicateResponse"
+                        }
+                    },
+                    "400": {
+                        "description": "Bad Request",
+                        "schema": {
+                            "$ref": "#/definitions/models.CheckEmailDuplicateResponse"
+                        }
+                    }
+                }
+            }
+        },
         "/api/v1/user/{id}/": {
             "get": {
                 "produces": [
@@ -489,6 +524,18 @@
                 },
                 "userID": {
                     "type": "integer"
+                }
+            }
+        },
+        "models.CheckEmailDuplicateResponse": {
+            "type": "object",
+            "properties": {
+                "data": {},
+                "error": {
+                    "type": "boolean"
+                },
+                "message": {
+                    "type": "string"
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -216,7 +216,7 @@
                 }
             }
         },
-        "/api/v1/user/": {
+        "/api/v1/user": {
             "get": {
                 "produces": [
                     "application/json"
@@ -328,9 +328,9 @@
                 }
             }
         },
-        "/api/v1/user/check-email/": {
+        "/api/v1/user/check-email": {
             "get": {
-                "description": "입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 \"True\" 반환, 없다면 \"False\" 반환.",
+                "description": "입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 True 반환, 없다면 False 반환.",
                 "produces": [
                     "application/json"
                 ],
@@ -359,11 +359,17 @@
                         "schema": {
                             "$ref": "#/definitions/models.CheckEmailDuplicateResponse"
                         }
+                    },
+                    "500": {
+                        "description": "Internal Server Error",
+                        "schema": {
+                            "$ref": "#/definitions/models.CheckEmailDuplicateResponse"
+                        }
                     }
                 }
             }
         },
-        "/api/v1/user/{id}/": {
+        "/api/v1/user/{id}": {
             "get": {
                 "produces": [
                     "application/json"

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -287,7 +287,7 @@ paths:
       summary: 특정 유저가 저장한 북마크 중 id가 일치하는 북마크 상세 정보 1개를 반환
       tags:
       - bookmark
-  /api/v1/user/:
+  /api/v1/user:
     get:
       parameters:
       - description: limit과 offset은 같이 입력해야 합니다.
@@ -354,7 +354,7 @@ paths:
       summary: 새 유저를 추가하는 API
       tags:
       - user
-  /api/v1/user/{id}/:
+  /api/v1/user/{id}:
     get:
       parameters:
       - description: User ID
@@ -385,9 +385,9 @@ paths:
       summary: UserID를 사용해 유저 1명 정보 읽기
       tags:
       - user
-  /api/v1/user/check-email/:
+  /api/v1/user/check-email:
     get:
-      description: 입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 "True" 반환, 없다면 "False" 반환.
+      description: 입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 True 반환, 없다면 False 반환.
       parameters:
       - description: 중복 체크 할 이메일 주소 입력. 최대 길이 50자 제한.
         in: query
@@ -403,6 +403,10 @@ paths:
             $ref: '#/definitions/models.CheckEmailDuplicateResponse'
         "400":
           description: Bad Request
+          schema:
+            $ref: '#/definitions/models.CheckEmailDuplicateResponse'
+        "500":
+          description: Internal Server Error
           schema:
             $ref: '#/definitions/models.CheckEmailDuplicateResponse'
       summary: 이메일 중복 체크.

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -76,6 +76,14 @@ definitions:
       userID:
         type: integer
     type: object
+  models.CheckEmailDuplicateResponse:
+    properties:
+      data: {}
+      error:
+        type: boolean
+      message:
+        type: string
+    type: object
   models.GetAllBookmarksResponse:
     properties:
       data: {}
@@ -375,6 +383,29 @@ paths:
           schema:
             $ref: '#/definitions/models.AddUserResponse'
       summary: UserID를 사용해 유저 1명 정보 읽기
+      tags:
+      - user
+  /api/v1/user/check-email/:
+    get:
+      description: 입력한 이메일을 사용하는 유저가 있다면 Body의 Message로 "True" 반환, 없다면 "False" 반환.
+      parameters:
+      - description: 중복 체크 할 이메일 주소 입력. 최대 길이 50자 제한.
+        in: query
+        name: email
+        required: true
+        type: string
+      produces:
+      - application/json
+      responses:
+        "200":
+          description: OK
+          schema:
+            $ref: '#/definitions/models.CheckEmailDuplicateResponse'
+        "400":
+          description: Bad Request
+          schema:
+            $ref: '#/definitions/models.CheckEmailDuplicateResponse'
+      summary: 이메일 중복 체크.
       tags:
       - user
 swagger: "2.0"


### PR DESCRIPTION
## 이슈

- #46 

## 작업 사항

- 이메일 중복 체크 API 엔드포인트 `/api/v1/user/check-email?email=cheesecat47@gmail.com` 추가.
- 핸들러에서 사용할 요청/응답 모델 생성.
- 이번에는 TDD 방법론으로 테스트 코드를 먼저 작성한 후에 진행.
- 이전 테스트코드 커밋에서 `httptest` 패키지의 `Query()`와 `Encode()`를 사용하도록 작성했는데 이렇게 하니 이메일이 cheesecat47@gmail.com이 아니라 gmail.com만 들어가서 오류가 발생했음. 그래서 fmt.Sprintf로 직접 입력.
- REST API URL 끝에 슬래시는 붙이지 말라고 해서 제거 -> 추후 다른 API에도 다 제거 필요.
- Swagger 업데이트

## 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
