### PR TITLE
[BE] fix: 로그인 시 헤더에 넣을 정보 ID에서 Email로 수정 (#56)

### DIFF
--- a/backend/app/controllers/auth.go
+++ b/backend/app/controllers/auth.go
@@ -16,7 +16,7 @@ import (
 // LogInHandler
 //
 //	@Summary		로그인 API
-//	@Description	로그인 성공 시 200 "Success" 메시지 반환.
+//	@Description	로그인 성공 시 200 "Success" 메시지와 함께 Data로 AccessToken을 반환.
 //	@Description	이메일 문제 시 400 "Email not found", 비밀번호 문제 시 "Failed to login" 반환.
 //	@Description	로그인 중 서버 문제 발생 시 "Failed to check ***" 반환.
 //	@Tags			auth
@@ -106,7 +106,7 @@ func LogInHandler(c *fiber.Ctx) error {
 	}
 
 	claims := jwt.MapClaims{
-		"user_id":   user.ID,
+		"email":     params.Email,
 		"authority": user.Authority,
 		"exp":       time.Now().Add(time.Hour * 72).Unix(),
 		"iss":       "cheesecat47@gmail.com@Nutbooks",

--- a/backend/app/controllers/user.go
+++ b/backend/app/controllers/user.go
@@ -11,7 +11,6 @@ import (
 	"github.com/gofiber/fiber/v2/log"
 	"github.com/golang-jwt/jwt/v5"
 	"gorm.io/gorm"
-	"strconv"
 )
 
 // AddUserHandler
@@ -127,7 +126,7 @@ func AddUserHandler(c *fiber.Ctx) error {
 //	@Tags		user
 //	@Produce	json
 //	@Security	ApiKeyAuth
-//	@Param		User-Id	header		int		true	"현재 유저 아이디"
+//	@Param		Email	header		string	true	"현재 유저 이메일"
 //	@Param		id		path		uint	true	"User ID"
 //	@Success	200		{object}	models.GetUserByIdResponse
 //	@Failure	400		{object}	models.GetUserByIdWithErrorResponse
@@ -144,8 +143,7 @@ func GetUserByIdHandler(c *fiber.Ctx) error {
 			Data:    err,
 		})
 	}
-	u64, _ := strconv.ParseUint(c.GetReqHeaders()["User-Id"], 10, 0)
-	params.UserID = uint(u64)
+	params.Email = c.GetReqHeaders()["Email"]
 
 	validator := &utils.Validator{}
 	validateErrs := validator.Validate(params)
@@ -159,7 +157,7 @@ func GetUserByIdHandler(c *fiber.Ctx) error {
 	log.Infow("[func GetUserByIdHandler]", "params", params)
 
 	token := c.Locals("user").(*jwt.Token)
-	err = middlewares.ValidToken(token, params.UserID)
+	err = middlewares.ValidToken(token, params.Email)
 	if err != nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(models.GetUserByIdWithErrorResponse{
 			Error:   true,
@@ -199,9 +197,9 @@ func GetUserByIdHandler(c *fiber.Ctx) error {
 //	@Tags		user
 //	@Produce	json
 //	@Security	ApiKeyAuth
-//	@Param		User-Id	header		int	true	"현재 유저 아이디"
-//	@Param		offset	query		int	false	"특정 id부터 조회할 때 사용"
-//	@Param		limit	query		int	false	"limit 개수만큼 조회할 때 사용"
+//	@Param		Email	header		string	true	"현재 유저 이메일"
+//	@Param		offset	query		int		false	"특정 id부터 조회할 때 사용"
+//	@Param		limit	query		int		false	"limit 개수만큼 조회할 때 사용"
 //	@Success	200		{object}	models.GetAllUsersResponse
 //	@Failure	400		{object}	models.GetAllUsersWithErrorResponse
 //	@Failure	401		{object}	models.GetAllUsersWithErrorResponse
@@ -217,8 +215,7 @@ func GetAllUsersHandler(c *fiber.Ctx) error {
 			Data:    err,
 		})
 	}
-	u64, _ := strconv.ParseUint(c.GetReqHeaders()["User-Id"], 10, 0)
-	params.UserID = uint(u64)
+	params.Email = c.GetReqHeaders()["Email"]
 
 	validator := &utils.Validator{}
 	validateErrs := validator.Validate(params)
@@ -232,7 +229,7 @@ func GetAllUsersHandler(c *fiber.Ctx) error {
 	log.Infow("[func GetAllUsersHandler]", "params", params)
 
 	token := c.Locals("user").(*jwt.Token)
-	err = middlewares.ValidToken(token, params.UserID)
+	err = middlewares.ValidToken(token, params.Email)
 	if err != nil {
 		return c.Status(fiber.StatusUnauthorized).JSON(models.GetAllUsersWithErrorResponse{
 			Error:   true,

--- a/backend/app/middlewares/jwt_middleware.go
+++ b/backend/app/middlewares/jwt_middleware.go
@@ -16,12 +16,12 @@ func Protected() fiber.Handler {
 	})
 }
 
-func ValidToken(t *jwt.Token, id uint) error {
+func ValidToken(t *jwt.Token, email string) error {
 	claims := t.Claims.(jwt.MapClaims)
-	if int(claims["user_id"].(float64)) == int(id) {
+	if claims["email"] == email {
 		return nil
 	} else {
-		return errors.New("Invalid token")
+		return errors.New("invalid token")
 	}
 }
 

--- a/backend/db/models/bookmark.go
+++ b/backend/db/models/bookmark.go
@@ -25,7 +25,10 @@ type Bookmark struct {
 // [api/app/controllers.AddBookmarkHandler]에서 사용하는 요청/응답 구조체
 type (
 	AddBookmarkRequest struct {
-		UserID uint `validate:"required,number,min=1" json:"user_id"`
+		// 5~50자 길이. 자세한 형식은 [go-playground/validator] 참고
+		//
+		// [go-playground/validator]: https://github.com/go-playground/validator
+		Email string `validate:"required,min=5,max=50,email" json:"email" form:"email"`
 
 		// 북마크 제목. 공백이면 og:title로 대체
 		Title string `default:"" json:"title"`
@@ -52,8 +55,12 @@ type (
 // [api/app/controllers.GetBookmarkByIdHandler]에서 사용하는 요청/응답 구조체
 type (
 	GetBookmarkByIdRequest struct {
-		ID     uint `validate:"required,number,min=1" json:"id"`
-		UserID uint `validate:"required,number,min=1" json:"user_id"`
+		ID uint `validate:"required,number,min=1" json:"id"`
+
+		// 5~50자 길이. 자세한 형식은 [go-playground/validator] 참고
+		//
+		// [go-playground/validator]: https://github.com/go-playground/validator
+		Email string `validate:"required,min=5,max=50,email" json:"email" form:"email"`
 	}
 
 	GetBookmarkByIdResponse struct {
@@ -72,7 +79,10 @@ type (
 // [api/app/controllers.GetAllBookmarksHandler]에서 사용하는 요청/응답 구조체
 type (
 	GetAllBookmarksRequest struct {
-		UserID uint `validate:"required,number,min=1" json:"user_id"`
+		// 5~50자 길이. 자세한 형식은 [go-playground/validator] 참고
+		//
+		// [go-playground/validator]: https://github.com/go-playground/validator
+		Email string `validate:"required,min=5,max=50,email" json:"email" form:"email"`
 
 		// 특정 id부터 조회할 때 사용
 		Offset int `validate:"number,min=0" json:"offset"`

--- a/backend/db/models/user.go
+++ b/backend/db/models/user.go
@@ -78,8 +78,12 @@ type (
 // [api/app/controllers.GetUserByIdHandler]에서 사용하는 요청/응답 구조체
 type (
 	GetUserByIdRequest struct {
-		ID     uint `validate:"required,number,min=1" json:"id"`
-		UserID uint `validate:"required,number,min=1" json:"user_id"`
+		ID uint `validate:"required,number,min=1" json:"id"`
+
+		// 5~50자 길이. 자세한 형식은 [go-playground/validator] 참고
+		//
+		// [go-playground/validator]: https://github.com/go-playground/validator
+		Email string `validate:"required,min=5,max=50,email" json:"email" form:"email"`
 	}
 
 	GetUserByIdResponse struct {
@@ -98,7 +102,10 @@ type (
 // [api/app/controllers.GetAllUsersHandler]에서 사용하는 요청/응답 구조체
 type (
 	GetAllUsersRequest struct {
-		UserID uint `validate:"required,number,min=1" json:"user_id"`
+		// 5~50자 길이. 자세한 형식은 [go-playground/validator] 참고
+		//
+		// [go-playground/validator]: https://github.com/go-playground/validator
+		Email string `validate:"required,min=5,max=50,email" json:"email" form:"email"`
 
 		// 특정 id부터 조회할 때 사용
 		Offset int `validate:"number,min=0" json:"offset"`

--- a/backend/docs/docs.go
+++ b/backend/docs/docs.go
@@ -33,7 +33,7 @@ const docTemplate = `{
         },
         "/auth/login": {
             "post": {
-                "description": "로그인 성공 시 200 \"Success\" 메시지 반환.\n이메일 문제 시 400 \"Email not found\", 비밀번호 문제 시 \"Failed to login\" 반환.\n로그인 중 서버 문제 발생 시 \"Failed to check ***\" 반환.",
+                "description": "로그인 성공 시 200 \"Success\" 메시지와 함께 Data로 AccessToken을 반환.\n이메일 문제 시 400 \"Email not found\", 비밀번호 문제 시 \"Failed to login\" 반환.\n로그인 중 서버 문제 발생 시 \"Failed to check ***\" 반환.",
                 "produces": [
                     "application/json"
                 ],
@@ -96,9 +96,9 @@ const docTemplate = `{
                 "summary": "특정 유저가 저장한 북마크 중 offset부터 limit까지 목록을 반환",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "email",
                         "in": "header",
                         "required": true
                     },
@@ -161,9 +161,9 @@ const docTemplate = `{
                 "summary": "특정 유저가 북마크를 DB에 추가하는 API",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "email",
                         "in": "header",
                         "required": true
                     },
@@ -215,9 +215,9 @@ const docTemplate = `{
                 "summary": "특정 유저가 저장한 북마크 중 id가 일치하는 북마크 상세 정보 1개를 반환",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "email",
                         "in": "header",
                         "required": true
                     },
@@ -273,9 +273,9 @@ const docTemplate = `{
                 "summary": "모든 유저 목록 반환",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "Email",
                         "in": "header",
                         "required": true
                     },
@@ -420,9 +420,9 @@ const docTemplate = `{
                 "summary": "UserID를 사용해 유저 1명 정보 읽기",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "email",
                         "in": "header",
                         "required": true
                     },
@@ -479,10 +479,16 @@ const docTemplate = `{
         "models.AddBookmarkRequest": {
             "type": "object",
             "required": [
-                "link",
-                "user_id"
+                "email",
+                "link"
             ],
             "properties": {
+                "email": {
+                    "description": "5~50자 길이. 자세한 형식은 [go-playground/validator] 참고\n\n[go-playground/validator]: https://github.com/go-playground/validator",
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 5
+                },
                 "link": {
                     "description": "북마크(웹사이트) 링크. 자세한 형식은 [go-playground/validator] 참고\n\n[go-playground/validator]: https://github.com/go-playground/validator",
                     "type": "string",
@@ -491,10 +497,6 @@ const docTemplate = `{
                 "title": {
                     "description": "북마크 제목. 공백이면 og:title로 대체",
                     "type": "string"
-                },
-                "user_id": {
-                    "type": "integer",
-                    "minimum": 1
                 }
             }
         },

--- a/backend/docs/swagger.json
+++ b/backend/docs/swagger.json
@@ -25,7 +25,7 @@
         },
         "/auth/login": {
             "post": {
-                "description": "로그인 성공 시 200 \"Success\" 메시지 반환.\n이메일 문제 시 400 \"Email not found\", 비밀번호 문제 시 \"Failed to login\" 반환.\n로그인 중 서버 문제 발생 시 \"Failed to check ***\" 반환.",
+                "description": "로그인 성공 시 200 \"Success\" 메시지와 함께 Data로 AccessToken을 반환.\n이메일 문제 시 400 \"Email not found\", 비밀번호 문제 시 \"Failed to login\" 반환.\n로그인 중 서버 문제 발생 시 \"Failed to check ***\" 반환.",
                 "produces": [
                     "application/json"
                 ],
@@ -88,9 +88,9 @@
                 "summary": "특정 유저가 저장한 북마크 중 offset부터 limit까지 목록을 반환",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "email",
                         "in": "header",
                         "required": true
                     },
@@ -153,9 +153,9 @@
                 "summary": "특정 유저가 북마크를 DB에 추가하는 API",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "email",
                         "in": "header",
                         "required": true
                     },
@@ -207,9 +207,9 @@
                 "summary": "특정 유저가 저장한 북마크 중 id가 일치하는 북마크 상세 정보 1개를 반환",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "email",
                         "in": "header",
                         "required": true
                     },
@@ -265,9 +265,9 @@
                 "summary": "모든 유저 목록 반환",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "Email",
                         "in": "header",
                         "required": true
                     },
@@ -412,9 +412,9 @@
                 "summary": "UserID를 사용해 유저 1명 정보 읽기",
                 "parameters": [
                     {
-                        "type": "integer",
-                        "description": "현재 유저 아이디",
-                        "name": "User-Id",
+                        "type": "string",
+                        "description": "현재 유저 이메일",
+                        "name": "email",
                         "in": "header",
                         "required": true
                     },
@@ -471,10 +471,16 @@
         "models.AddBookmarkRequest": {
             "type": "object",
             "required": [
-                "link",
-                "user_id"
+                "email",
+                "link"
             ],
             "properties": {
+                "email": {
+                    "description": "5~50자 길이. 자세한 형식은 [go-playground/validator] 참고\n\n[go-playground/validator]: https://github.com/go-playground/validator",
+                    "type": "string",
+                    "maxLength": 50,
+                    "minLength": 5
+                },
                 "link": {
                     "description": "북마크(웹사이트) 링크. 자세한 형식은 [go-playground/validator] 참고\n\n[go-playground/validator]: https://github.com/go-playground/validator",
                     "type": "string",
@@ -483,10 +489,6 @@
                 "title": {
                     "description": "북마크 제목. 공백이면 og:title로 대체",
                     "type": "string"
-                },
-                "user_id": {
-                    "type": "integer",
-                    "minimum": 1
                 }
             }
         },

--- a/backend/docs/swagger.yaml
+++ b/backend/docs/swagger.yaml
@@ -10,6 +10,14 @@ definitions:
     type: object
   models.AddBookmarkRequest:
     properties:
+      email:
+        description: |-
+          5~50자 길이. 자세한 형식은 [go-playground/validator] 참고
+
+          [go-playground/validator]: https://github.com/go-playground/validator
+        maxLength: 50
+        minLength: 5
+        type: string
       link:
         description: |-
           북마크(웹사이트) 링크. 자세한 형식은 [go-playground/validator] 참고
@@ -20,12 +28,9 @@ definitions:
       title:
         description: 북마크 제목. 공백이면 og:title로 대체
         type: string
-      user_id:
-        minimum: 1
-        type: integer
     required:
+    - email
     - link
-    - user_id
     type: object
   models.AddBookmarkResponse:
     properties:
@@ -322,7 +327,7 @@ paths:
   /auth/login:
     post:
       description: |-
-        로그인 성공 시 200 "Success" 메시지 반환.
+        로그인 성공 시 200 "Success" 메시지와 함께 Data로 AccessToken을 반환.
         이메일 문제 시 400 "Email not found", 비밀번호 문제 시 "Failed to login" 반환.
         로그인 중 서버 문제 발생 시 "Failed to check ***" 반환.
       parameters:
@@ -357,11 +362,11 @@ paths:
   /bookmark:
     get:
       parameters:
-      - description: 현재 유저 아이디
+      - description: 현재 유저 이메일
         in: header
-        name: User-Id
+        name: email
         required: true
-        type: integer
+        type: string
       - description: 특정 id부터 조회할 때 사용
         in: query
         name: offset
@@ -399,11 +404,11 @@ paths:
       - application/json
       description: 새 북마크를 DB에 저장. 북마크 링크는 필수 데이터이고, 그 외는 옵셔널.
       parameters:
-      - description: 현재 유저 아이디
+      - description: 현재 유저 이메일
         in: header
-        name: User-Id
+        name: email
         required: true
-        type: integer
+        type: string
       - description: body params
         in: body
         name: params
@@ -433,11 +438,11 @@ paths:
   /bookmark/{id}:
     get:
       parameters:
-      - description: 현재 유저 아이디
+      - description: 현재 유저 이메일
         in: header
-        name: User-Id
+        name: email
         required: true
-        type: integer
+        type: string
       - description: Bookmark ID
         in: path
         name: id
@@ -470,11 +475,11 @@ paths:
   /user:
     get:
       parameters:
-      - description: 현재 유저 아이디
+      - description: 현재 유저 이메일
         in: header
-        name: User-Id
+        name: Email
         required: true
-        type: integer
+        type: string
       - description: 특정 id부터 조회할 때 사용
         in: query
         name: offset
@@ -538,11 +543,11 @@ paths:
   /user/{id}:
     get:
       parameters:
-      - description: 현재 유저 아이디
+      - description: 현재 유저 이메일
         in: header
-        name: User-Id
+        name: email
         required: true
-        type: integer
+        type: string
       - description: User ID
         in: path
         name: id


### PR DESCRIPTION
## 이슈

- #56

## 작업 사항

- 지난 JWT 로그인 구현 시 JWT 생성에 UserId를 사용하였으나, Email을 사용하도록 변경.
- 클라이언트 측에서 API 요청 시 Header Param으로 넣어주는 이메일과, 로그인 시 이메일 주소가 같은지 확인.

## 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
