### PR TITLE
[BE] feat: FE 개발서버를 위한 CORS Origin 추가 (#25)

### DIFF
--- a/backend/app/middlewares/cors_middleware.go
+++ b/backend/app/middlewares/cors_middleware.go
@@ -1,0 +1,30 @@
+package middlewares
+
+import (
+	"api/configs"
+	"github.com/gofiber/fiber/v2"
+	"github.com/gofiber/fiber/v2/middleware/cors"
+)
+
+func CorsMiddleware(app *fiber.App) {
+	origins := "https://nutbooks.koreacentral.cloudapp.azure.com"
+	if configs.FeDevHost != "" {
+		origins += ", " + configs.FeDevHost
+	}
+
+	app.Use(cors.New(cors.Config{
+		AllowOrigins: origins,
+		MaxAge:       600,
+	}))
+
+	app.Use(func(c *fiber.Ctx) error {
+		h := c.GetReqHeaders()
+		if configs.FeDevHost != "" && configs.CorsSecret != "" {
+			if h["Origin"] == configs.FeDevHost && h["X-Custom-Origin-Token"] == configs.CorsSecret {
+				return c.Next()
+			}
+		}
+		c.Response().Header.Set("Access-Control-Allow-Origin", "")
+		return c.SendStatus(fiber.StatusNoContent)
+	})
+}

--- a/backend/configs/config.go
+++ b/backend/configs/config.go
@@ -6,7 +6,9 @@ import (
 )
 
 var (
-	JWTSecret string
+	JWTSecret  string
+	FeDevHost  string
+	CorsSecret string
 )
 
 func Config() {
@@ -15,5 +17,15 @@ func Config() {
 	if !exists {
 		log.Fatalw("[func Protected] Missing JWT Secret", "JWTSecret", JWTSecret)
 		os.Exit(1)
+	}
+
+	FeDevHost, exists = os.LookupEnv("FE_DEV_HOST")
+	if !exists {
+		FeDevHost = ""
+	}
+
+	CorsSecret, exists = os.LookupEnv("CORS_SECRET")
+	if !exists {
+		CorsSecret = ""
 	}
 }

--- a/backend/docker-compose.dev.yml
+++ b/backend/docker-compose.dev.yml
@@ -13,12 +13,8 @@ services:
       - "./:/build"
       - ./wait-for-it.sh:/wait-for-it.sh
     environment:
-      MYSQL_ROOT_PASSWORD: ${MYSQL_ROOT_PASSWORD}
-      MYSQL_DATABASE: ${MYSQL_DATABASE}
-      MYSQL_USER: ${MYSQL_USER}
-      MYSQL_PASSWORD: ${MYSQL_PASSWORD}
-      MYSQL_HOST: mysql
-      MYSQL_PORT: 3306
+      FE_DEV_HOST: ${FE_DEV_HOST}
+      CORS_SECRET: ${CORS_SECRET}
     command:
       - /bin/bash
       - -c

--- a/backend/main.go
+++ b/backend/main.go
@@ -107,6 +107,7 @@ func runServer() {
 		ReadTimeout: 60 * time.Second,
 	})
 
+	middlewares.CorsMiddleware(app)
 	middlewares.FiberMiddleware(app)
 
 	// limit 3 requests per 10 seconds max


### PR DESCRIPTION
## 이슈

- #25

## 작업 사항

- CORS middleware 추가
  - Azure 서버 주소 Allow Origin으로 추가
  - FE 개발 서버 주소 localhost:3000도 추가
    - 다만, 개발 서버에서 접속 시에는 헤더에 key를 추가해줘야 cors 문제 발생 안하도록 제한함.


## 참고 사항

<!-- 공유할 내용, 스크린샷 등을 넣어 주세요. -->
